### PR TITLE
Bump base upper bounds to <4.18

### DIFF
--- a/shower.cabal
+++ b/shower.cabal
@@ -28,7 +28,7 @@ library
     Shower.Parser
     Shower.Class
   build-depends:
-    base >=4.10 && <4.16,
+    base >=4.10 && <4.18,
     megaparsec,
     pretty
   hs-source-dirs: lib
@@ -38,7 +38,7 @@ library
 executable shower
   main-is: Main.hs
   build-depends:
-    base >=4.10 && <4.16,
+    base >=4.10 && <4.18,
     shower
   hs-source-dirs: exe
   default-language: Haskell2010
@@ -50,7 +50,7 @@ test-suite shower-tests
     Property
   type: exitcode-stdio-1.0
   build-depends:
-    base >=4.10 && <4.16,
+    base >=4.10 && <4.18,
     aeson,
     tasty,
     tasty-golden,

--- a/tests/Property.hs
+++ b/tests/Property.hs
@@ -1,10 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Property where
 
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.UTF8 as UTF8
 
@@ -12,18 +12,32 @@ import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+#else
+import qualified Data.HashMap.Strict as HashMap
+#endif
+
 import Shower
 
 -- | 'Aeson.Value' generator, stolen from @api-tools@.
 genJSON :: Gen Aeson.Value
 genJSON = sized $ \size -> oneof [
-    Aeson.Object . HashMap.fromList <$>
-        resize (size `div` 2) (listOf ((,) <$> (Text.pack <$> arbitrary) <*> genJSON)),
+    Aeson.Object . objectFromList <$>
+        resize (size `div` 2) (listOf ((,) <$> (keyFromText . Text.pack <$> arbitrary) <*> genJSON)),
     Aeson.Array . Vector.fromList <$> resize (size `div` 2) (listOf genJSON),
     Aeson.String . Text.pack <$> arbitrary,
     Aeson.Number . fromInteger <$> arbitrary,
     Aeson.Bool <$> arbitrary,
     pure Aeson.Null ]
+  where
+    (objectFromList, keyFromText) =
+#if MIN_VERSION_aeson(2,0,0)
+      (KeyMap.fromList, Key.fromText)
+#else
+      (HashMap.fromList, id)
+#endif
 
 -- | Test that formatting always works on JSON and never changes it.
 prop_JSON :: Property


### PR DESCRIPTION
With this change it builds and passes tests with ghc-8.10.7, ghc-9.2.4 and ghc-9.4.2.

```
> cabal test all --test-show-details=always
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - shower-0.2.0.3 (lib) (configuration changed)
 - shower-0.2.0.3 (test:shower-tests) (configuration changed)
Configuring library for shower-0.2.0.3..
Preprocessing library for shower-0.2.0.3..
Building library for shower-0.2.0.3..
Configuring test suite 'shower-tests' for shower-0.2.0.3..
Preprocessing test suite 'shower-tests' for shower-0.2.0.3..
Building test suite 'shower-tests' for shower-0.2.0.3..
Running 1 test suites...
Test suite shower-tests: RUNNING...
Shower
  in/out
    Basic:                               OK
    Commas:                              OK
    JSON:                                OK
    Lists:                               OK
    Literals:                            OK
    Misc:                                OK
    Suboptimal:                          OK
    Time:                                OK
    Tuples:                              OK
    TypeReps:                            OK
    UUIDs:                               OK
    Units:                               OK
  
    prop_JSON from tests/Property.hs:43: OK (0.02s)
      +++ OK, passed 100 tests.

All 13 tests passed (0.02s)

Test suite shower-tests: PASS

> cabal test all --test-show-details=always
Resolving dependencies...
Build profile: -w ghc-9.2.4 -O1
In order, the following will be built (use -v for more details):
 - shower-0.2.0.3 (lib) (first run)
 - shower-0.2.0.3 (test:shower-tests) (first run)
Configuring library for shower-0.2.0.3..
Preprocessing library for shower-0.2.0.3..
Building library for shower-0.2.0.3..
...
Running 1 test suites...
Test suite shower-tests: RUNNING...
Shower
  in/out
    Basic:                               OK
    Commas:                              OK
    JSON:                                OK
    Lists:                               OK
    Literals:                            OK
    Misc:                                OK
    Suboptimal:                          OK
    Time:                                OK
    Tuples:                              OK
    TypeReps:                            OK
    UUIDs:                               OK
    Units:                               OK
  
    prop_JSON from tests/Property.hs:43: OK (0.04s)
      +++ OK, passed 100 tests.

All 13 tests passed (0.05s)

Test suite shower-tests: PASS

> cabal test all --test-show-details=always
Resolving dependencies...
Build profile: -w ghc-9.4.2 -O1
In order, the following will be built (use -v for more details):
 - shower-0.2.0.3 (lib) (first run)
 - shower-0.2.0.3 (test:shower-tests) (first run)
Configuring library for shower-0.2.0.3..
Preprocessing library for shower-0.2.0.3..
Building library for shower-0.2.0.3..
...
Test suite shower-tests: RUNNING...
Shower
  in/out
    Basic:                               OK
    Commas:                              OK
    JSON:                                OK
    Lists:                               OK
    Literals:                            OK
    Misc:                                OK
    Suboptimal:                          OK
    Time:                                OK
    Tuples:                              OK
    TypeReps:                            OK
    UUIDs:                               OK
    Units:                               OK
  
    prop_JSON from tests/Property.hs:43: OK (0.02s)
      +++ OK, passed 100 tests.

All 13 tests passed (0.03s)

Test suite shower-tests: PASS
```