### PR TITLE
Allow base from GHC-9.10

### DIFF
--- a/shower.cabal
+++ b/shower.cabal
@@ -28,7 +28,7 @@ library
     Shower.Parser
     Shower.Class
   build-depends:
-    base >=4.10 && <4.18,
+    base >=4.10 && <4.21,
     megaparsec,
     pretty
   hs-source-dirs: lib
@@ -38,7 +38,7 @@ library
 executable shower
   main-is: Main.hs
   build-depends:
-    base >=4.10 && <4.18,
+    base,
     shower
   hs-source-dirs: exe
   default-language: Haskell2010
@@ -50,7 +50,7 @@ test-suite shower-tests
     Property
   type: exitcode-stdio-1.0
   build-depends:
-    base >=4.10 && <4.18,
+    base,
     aeson,
     tasty,
     tasty-golden,


### PR DESCRIPTION
Removed redundant sub-component restrictions on base.